### PR TITLE
Add patch to leaflet to fix panels field formatter support

### DIFF
--- a/makefiles/modules.make.yml
+++ b/makefiles/modules.make.yml
@@ -64,7 +64,10 @@ projects:
   inline_messages: { version: ~ }
   jquery_update: { version: ~ }
   job_scheduler: { version: ~ }
-  leaflet: { version: ~ }
+  leaflet:
+    version: ~
+    patch:
+      - https://www.drupal.org/files/issues/field-formatter-errors-2185767-6.patch
   leaflet_more_maps: { version: ~ }
   libraries: { version: ~ }
   link: { version: ~ }

--- a/rune.make
+++ b/rune.make
@@ -164,6 +164,7 @@ projects[job_scheduler][version] = "2.0-alpha3"
 projects[job_scheduler][subdir] = "contrib"
 
 projects[leaflet][version] = "1.1"
+projects[leaflet][patch][0] = "https://www.drupal.org/files/issues/field-formatter-errors-2185767-6.patch"
 projects[leaflet][subdir] = "contrib"
 
 projects[leaflet_more_maps][version] = "1.10"


### PR DESCRIPTION
Confirmed to fix the issue at https://www.drupal.org/node/2185767

When adding a geocoded field and selecting the Leaflet formatter, would cause ajax 500 error.
