### PR TITLE
Add patches to expose the generate button and set a default version.

### DIFF
--- a/makefiles/modules.make.yml
+++ b/makefiles/modules.make.yml
@@ -38,6 +38,8 @@ projects:
     download: { branch: 7.x-2.x }
     patch:
       - https://www.drupal.org/files/issues/1064340-features-files-13.patch
+      - https://www.drupal.org/files/issues/features-defaultversion-2467705-1.patch
+      - https://www.drupal.org/files/issues/features-add_generate_button-401392-1.patch
   features_override: { version: ~ }
   feeds:
     download: { branch: 2.x-dev, revision: f22a0f7 }

--- a/rune.make
+++ b/rune.make
@@ -99,6 +99,8 @@ projects[eva][subdir] = "contrib"
 projects[features][download][branch] = "7.x-2.x"
 projects[features][download][type] = "git"
 projects[features][patch][0] = "https://www.drupal.org/files/issues/1064340-features-files-13.patch"
+projects[features][patch][1] = "https://www.drupal.org/files/issues/features-defaultversion-2467705-1.patch"
+projects[features][patch][2] = "https://www.drupal.org/files/issues/features-add_generate_button-401392-1.patch"
 projects[features][subdir] = "contrib"
 
 projects[features_override][version] = "2.0-rc2"


### PR DESCRIPTION
I added two patches, one will expose the generate button reducing the hassle of having to twirl open the advanced options. The second sets a default version of 7.x-1.0 instead of leaving it empty reducing the hassle of adding that every time a new feature is created.
