### PR TITLE
Fix flag module's lack of error-checking

### DIFF
--- a/makefiles/modules.make.yml
+++ b/makefiles/modules.make.yml
@@ -61,7 +61,10 @@ projects:
     patch:
       - https://www.drupal.org/files/issues/deprecated_e-2103151-26.patch
   filefield_sources: { version: ~ }
-  flag: { version: ~ }
+  flag:
+    version: ~
+    patch:
+      - https://www.drupal.org/files/issues/flag-broken-1925922-131.patch
   flexslider: { version: ~ }
   geocoder: { version: ~ }
   geofield: { version: ~ }

--- a/makefiles/modules.make.yml
+++ b/makefiles/modules.make.yml
@@ -65,6 +65,8 @@ projects:
     version: ~
     patch:
       - https://www.drupal.org/files/issues/flag-broken-1925922-131.patch
+      - https://www.drupal.org/files/issues/1925922-flag-fixed-warning-76.patch
+      - https://www.drupal.org/files/issues/line-130-fixer-upper-rater-19252922-46_1.patch
   flexslider: { version: ~ }
   geocoder: { version: ~ }
   geofield: { version: ~ }

--- a/rune.make
+++ b/rune.make
@@ -4,382 +4,385 @@ api = 2
 
 ; Core
 ; Themes
-projects[adminimal_theme][version] = "1.21"
 projects[adminimal_theme][subdir] = "contrib"
+projects[adminimal_theme][version] = "1.21"
 projects[adminimal_theme][type] = "theme"
 
-projects[bootstrap][version] = "3.0"
 projects[bootstrap][subdir] = "contrib"
+projects[bootstrap][version] = "3.0"
 projects[bootstrap][type] = "theme"
 
-projects[omega][version] = "4.3"
 projects[omega][subdir] = "contrib"
+projects[omega][version] = "4.3"
 projects[omega][type] = "theme"
 
 ; Modules
+projects[addressfield][subdir] = "contrib"
 projects[addressfield][version] = "1.1"
 projects[addressfield][patch][0] = "https://www.drupal.org/files/issues/addressfield-nonempty-1263316-98.patch"
-projects[addressfield][subdir] = "contrib"
 
-projects[addressfield_staticmap][version] = "1.0"
 projects[addressfield_staticmap][subdir] = "contrib"
+projects[addressfield_staticmap][version] = "1.0"
 
+projects[admin_menu][subdir] = "contrib"
 projects[admin_menu][version] = "3.0-rc5"
 projects[admin_menu][patch][0] = "https://www.drupal.org/files/admin_menu-search-disappeared-1916812-13.patch"
-projects[admin_menu][subdir] = "contrib"
 
-projects[admin_views][version] = "1.4"
 projects[admin_views][subdir] = "contrib"
+projects[admin_views][version] = "1.4"
 
-projects[adminimal_admin_menu][version] = "1.5"
 projects[adminimal_admin_menu][subdir] = "contrib"
+projects[adminimal_admin_menu][version] = "1.5"
 
-projects[auto_entitylabel][version] = "1.3"
 projects[auto_entitylabel][subdir] = "contrib"
+projects[auto_entitylabel][version] = "1.3"
 
-projects[better_exposed_filters][version] = "3.2"
 projects[better_exposed_filters][subdir] = "contrib"
+projects[better_exposed_filters][version] = "3.2"
 
-projects[better_formats][version] = "1.0-beta1"
 projects[better_formats][subdir] = "contrib"
+projects[better_formats][version] = "1.0-beta1"
 
-projects[bg_image][version] = "1.4"
 projects[bg_image][subdir] = "contrib"
+projects[bg_image][version] = "1.4"
 
-projects[bg_image_formatter][version] = "1.3"
 projects[bg_image_formatter][subdir] = "contrib"
+projects[bg_image_formatter][version] = "1.3"
 
-projects[ckeditor][version] = "1.16"
 projects[ckeditor][subdir] = "contrib"
+projects[ckeditor][version] = "1.16"
 
-projects[coffee][version] = "2.2"
 projects[coffee][subdir] = "contrib"
+projects[coffee][version] = "2.2"
 
-projects[colorbox][version] = "2.8"
 projects[colorbox][subdir] = "contrib"
+projects[colorbox][version] = "2.8"
 
-projects[computed_field][version] = "1.0"
 projects[computed_field][subdir] = "contrib"
+projects[computed_field][version] = "1.0"
 
-projects[content_menu][version] = "1.0"
 projects[content_menu][subdir] = "contrib"
+projects[content_menu][version] = "1.0"
 
-projects[contextual_range_filter][version] = "1.7"
 projects[contextual_range_filter][subdir] = "contrib"
+projects[contextual_range_filter][version] = "1.7"
 
-projects[ctools][version] = "1.7"
 projects[ctools][subdir] = "contrib"
+projects[ctools][version] = "1.7"
 
-projects[date][version] = "2.8"
 projects[date][subdir] = "contrib"
+projects[date][version] = "2.8"
 
-projects[diff][version] = "3.2"
 projects[diff][subdir] = "contrib"
+projects[diff][version] = "3.2"
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"
 
-projects[email_registration][version] = "1.2"
 projects[email_registration][subdir] = "contrib"
+projects[email_registration][version] = "1.2"
 
-projects[editablefields][version] = "1.0-alpha2"
 projects[editablefields][subdir] = "contrib"
+projects[editablefields][version] = "1.0-alpha2"
 
-projects[entity][version] = "1.6"
 projects[entity][subdir] = "contrib"
+projects[entity][version] = "1.6"
 
-projects[entity_view_mode][version] = "1.0-rc1"
 projects[entity_view_mode][subdir] = "contrib"
+projects[entity_view_mode][version] = "1.0-rc1"
 
-projects[entityreference][version] = "1.1"
 projects[entityreference][subdir] = "contrib"
+projects[entityreference][version] = "1.1"
 
-projects[eva][version] = "1.2"
 projects[eva][subdir] = "contrib"
+projects[eva][version] = "1.2"
 
+projects[features][subdir] = "contrib"
 projects[features][version] = "2.5"
 projects[features][patch][0] = "https://www.drupal.org/files/issues/1064340-features-files-13.patch"
-projects[features][subdir] = "contrib"
 
-projects[features_override][version] = "2.0-rc2"
 projects[features_override][subdir] = "contrib"
+projects[features_override][version] = "2.0-rc2"
 
+projects[feeds][subdir] = "contrib"
 projects[feeds][download][branch] = "2.x-dev"
 projects[feeds][download][revision] = "f22a0f7"
 projects[feeds][download][type] = "git"
-projects[feeds][subdir] = "contrib"
 
-projects[feeds_tamper][version] = "1.0"
 projects[feeds_tamper][subdir] = "contrib"
+projects[feeds_tamper][version] = "1.0"
 
-projects[feeds_xpathparser][version] = "1.0"
 projects[feeds_xpathparser][subdir] = "contrib"
+projects[feeds_xpathparser][version] = "1.0"
 
-projects[fences][version] = "1.0"
 projects[fences][subdir] = "contrib"
+projects[fences][version] = "1.0"
 
+projects[field_collection][subdir] = "contrib"
 projects[field_collection][version] = "1.0-beta8"
 projects[field_collection][patch][0] = "https://www.drupal.org/files/issues/field_collection-host_entity_tokens-1372652-74.patch"
-projects[field_collection][subdir] = "contrib"
 
+projects[field_collection_feeds][subdir] = "contrib"
 projects[field_collection_feeds][version] = "1.0-alpha3"
 projects[field_collection_feeds][patch][0] = "https://www.drupal.org/files/issues/FeedsUpdateIssue-1921128-12.patch"
-projects[field_collection_feeds][subdir] = "contrib"
 
-projects[field_group][version] = "1.4"
 projects[field_group][subdir] = "contrib"
+projects[field_group][version] = "1.4"
 
+projects[field_validation][subdir] = "contrib"
 projects[field_validation][download][branch] = "2.x-dev"
 projects[field_validation][download][revision] = "63e1e83"
 projects[field_validation][download][type] = "git"
-projects[field_validation][subdir] = "contrib"
 
-projects[file_entity][version] = "2.0-beta1"
 projects[file_entity][subdir] = "contrib"
+projects[file_entity][version] = "2.0-beta1"
 
+projects[filefield_paths][subdir] = "contrib"
 projects[filefield_paths][version] = "1.0-beta4"
 projects[filefield_paths][patch][0] = "https://www.drupal.org/files/issues/deprecated_e-2103151-26.patch"
-projects[filefield_paths][subdir] = "contrib"
 
-projects[filefield_sources][version] = "1.9"
 projects[filefield_sources][subdir] = "contrib"
+projects[filefield_sources][version] = "1.9"
 
-projects[flag][version] = "3.6"
 projects[flag][subdir] = "contrib"
+projects[flag][version] = "3.6"
+projects[flag][patch][0] = "https://www.drupal.org/files/issues/flag-broken-1925922-131.patch"
+projects[flag][patch][1] = "https://www.drupal.org/files/issues/1925922-flag-fixed-warning-76.patch"
+projects[flag][patch][2] = "https://www.drupal.org/files/issues/line-130-fixer-upper-rater-19252922-46_1.patch"
 
-projects[flexslider][version] = "2.0-alpha3"
 projects[flexslider][subdir] = "contrib"
+projects[flexslider][version] = "2.0-alpha3"
 
-projects[geocoder][version] = "1.2"
 projects[geocoder][subdir] = "contrib"
+projects[geocoder][version] = "1.2"
 
-projects[geofield][version] = "2.3"
 projects[geofield][subdir] = "contrib"
+projects[geofield][version] = "2.3"
 
-projects[geophp][version] = "1.7"
 projects[geophp][subdir] = "contrib"
+projects[geophp][version] = "1.7"
 
-projects[gtranslate][version] = "1.10"
 projects[gtranslate][subdir] = "contrib"
+projects[gtranslate][version] = "1.10"
 
-projects[hybridauth][version] = "2.12"
 projects[hybridauth][subdir] = "contrib"
+projects[hybridauth][version] = "2.12"
 
-projects[i18n][version] = "1.13"
 projects[i18n][subdir] = "contrib"
+projects[i18n][version] = "1.13"
 
-projects[iframe][version] = "1.3"
 projects[iframe][subdir] = "contrib"
+projects[iframe][version] = "1.3"
 
-projects[imageapi_optimize][version] = "1.2"
 projects[imageapi_optimize][subdir] = "contrib"
+projects[imageapi_optimize][version] = "1.2"
 
+projects[image_combination_effects][subdir] = "contrib"
 projects[image_combination_effects][version] = "1.0-alpha1"
 projects[image_combination_effects][patch][0] = "https://www.drupal.org/files/issues/ICE-fix-fatal-typecast-error-228133-2.patch"
-projects[image_combination_effects][subdir] = "contrib"
 
-projects[imagecache_actions][version] = "1.5"
 projects[imagecache_actions][subdir] = "contrib"
+projects[imagecache_actions][version] = "1.5"
 
-projects[imagecache_token][version] = "1.x-dev"
 projects[imagecache_token][subdir] = "contrib"
+projects[imagecache_token][version] = "1.x-dev"
 
-projects[imce][version] = "1.9"
 projects[imce][subdir] = "contrib"
+projects[imce][version] = "1.9"
 
-projects[imce_filefield][version] = "1.1"
 projects[imce_filefield][subdir] = "contrib"
+projects[imce_filefield][version] = "1.1"
 
-projects[inline_entity_form][version] = "1.5"
 projects[inline_entity_form][subdir] = "contrib"
+projects[inline_entity_form][version] = "1.5"
 
-projects[inline_messages][version] = "1.0"
 projects[inline_messages][subdir] = "contrib"
+projects[inline_messages][version] = "1.0"
 
-projects[jquery_update][version] = "3.0-alpha1"
 projects[jquery_update][subdir] = "contrib"
+projects[jquery_update][version] = "3.0-alpha1"
 
-projects[job_scheduler][version] = "2.0-alpha3"
 projects[job_scheduler][subdir] = "contrib"
+projects[job_scheduler][version] = "2.0-alpha3"
 
-projects[lang_dropdown][version] = "2.5"
 projects[lang_dropdown][subdir] = "contrib"
+projects[lang_dropdown][version] = "2.5"
 
+projects[leaflet][subdir] = "contrib"
 projects[leaflet][version] = "1.1"
 projects[leaflet][patch][0] = "https://www.drupal.org/files/issues/field-formatter-errors-2185767-6.patch"
-projects[leaflet][subdir] = "contrib"
 
-projects[leaflet_more_maps][version] = "1.11"
 projects[leaflet_more_maps][subdir] = "contrib"
+projects[leaflet_more_maps][version] = "1.11"
 
-projects[libraries][version] = "2.2"
 projects[libraries][subdir] = "contrib"
+projects[libraries][version] = "2.2"
 
-projects[link][version] = "1.3"
 projects[link][subdir] = "contrib"
+projects[link][version] = "1.3"
 
-projects[linkit][version] = "3.3"
 projects[linkit][subdir] = "contrib"
+projects[linkit][version] = "3.3"
 
+projects[mailsystem][subdir] = "contrib"
 projects[mailsystem][download][branch] = "3.x-dev"
 projects[mailsystem][download][revision] = "4c957ae"
 projects[mailsystem][download][type] = "git"
-projects[mailsystem][subdir] = "contrib"
 
-projects[manualcrop][version] = "1.5"
 projects[manualcrop][subdir] = "contrib"
+projects[manualcrop][version] = "1.5"
 
-projects[masquerade][version] = "1.0-rc7"
 projects[masquerade][subdir] = "contrib"
+projects[masquerade][version] = "1.0-rc7"
 
+projects[media][subdir] = "contrib"
 projects[media][download][branch] = "7.x-2.x"
 projects[media][download][type] = "git"
-projects[media][subdir] = "contrib"
 
-projects[menu_attributes][version] = "1.0-rc3"
 projects[menu_attributes][subdir] = "contrib"
+projects[menu_attributes][version] = "1.0-rc3"
 
+projects[metatag][subdir] = "contrib"
 projects[metatag][version] = "1.4"
 projects[metatag][patch][0] = "https://www.drupal.org/files/issues/metatag-substitute-panels-context-variables-2408211-8.patch"
-projects[metatag][subdir] = "contrib"
 
-projects[migrate][version] = "2.7"
 projects[migrate][subdir] = "contrib"
+projects[migrate][version] = "2.7"
 
-projects[mimemail][version] = "1.0-beta3"
 projects[mimemail][subdir] = "contrib"
+projects[mimemail][version] = "1.0-beta3"
 
-projects[module_filter][version] = "2.0"
 projects[module_filter][subdir] = "contrib"
+projects[module_filter][version] = "2.0"
 
-projects[office_hours][version] = "1.4"
 projects[office_hours][subdir] = "contrib"
+projects[office_hours][version] = "1.4"
 
+projects[panelizer][subdir] = "contrib"
 projects[panelizer][download][branch] = "3.x-dev"
 projects[panelizer][download][revision] = "dd5aacc"
 projects[panelizer][download][type] = "git"
-projects[panelizer][subdir] = "contrib"
 
-projects[panels][version] = "3.5"
 projects[panels][subdir] = "contrib"
+projects[panels][version] = "3.5"
 
-projects[panels_everywhere][version] = "1.0-rc2"
 projects[panels_everywhere][subdir] = "contrib"
+projects[panels_everywhere][version] = "1.0-rc2"
 
-projects[paragraphs][version] = "1.0-beta6"
 projects[paragraphs][subdir] = "contrib"
+projects[paragraphs][version] = "1.0-beta6"
 
-projects[pathauto][version] = "1.2"
 projects[pathauto][subdir] = "contrib"
+projects[pathauto][version] = "1.2"
 
-projects[phone][version] = "1.0-beta1"
 projects[phone][subdir] = "contrib"
+projects[phone][version] = "1.0-beta1"
 
-projects[profile2][version] = "1.3"
 projects[profile2][subdir] = "contrib"
+projects[profile2][version] = "1.3"
 
-projects[quicktabs][version] = "3.6"
 projects[quicktabs][subdir] = "contrib"
+projects[quicktabs][version] = "3.6"
 
-projects[rabbit_hole][version] = "2.23"
 projects[rabbit_hole][subdir] = "contrib"
+projects[rabbit_hole][version] = "2.23"
 
-projects[range][version] = "1.3"
 projects[range][subdir] = "contrib"
+projects[range][version] = "1.3"
 
-projects[rules][version] = "2.9"
 projects[rules][subdir] = "contrib"
+projects[rules][version] = "2.9"
 
-projects[save_edit][version] = "1.0-beta1"
 projects[save_edit][subdir] = "contrib"
+projects[save_edit][version] = "1.0-beta1"
 
-projects[services][version] = "3.12"
 projects[services][subdir] = "contrib"
+projects[services][version] = "3.12"
 
-projects[sharethis][version] = "2.10"
 projects[sharethis][subdir] = "contrib"
+projects[sharethis][version] = "2.10"
 
-projects[simplify][version] = "3.3"
 projects[simplify][subdir] = "contrib"
+projects[simplify][version] = "3.3"
 
-projects[xmlsitemap][version] = "2.2"
 projects[xmlsitemap][subdir] = "contrib"
+projects[xmlsitemap][version] = "2.2"
 
-projects[smtp][version] = "1.2"
 projects[smtp][subdir] = "contrib"
+projects[smtp][version] = "1.2"
 
-projects[strongarm][version] = "2.0"
 projects[strongarm][subdir] = "contrib"
+projects[strongarm][version] = "2.0"
 
-projects[subpathauto][version] = "1.3"
 projects[subpathauto][subdir] = "contrib"
+projects[subpathauto][version] = "1.3"
 
+projects[superfish][subdir] = "contrib"
 projects[superfish][download][branch] = "1.x-dev"
 projects[superfish][download][revision] = "fa3d7c6"
 projects[superfish][download][type] = "git"
-projects[superfish][subdir] = "contrib"
 
-projects[themekey][version] = "3.3"
 projects[themekey][subdir] = "contrib"
+projects[themekey][version] = "3.3"
 
-projects[title][version] = "1.0-alpha7"
 projects[title][subdir] = "contrib"
+projects[title][version] = "1.0-alpha7"
 
-projects[token][version] = "1.6"
 projects[token][subdir] = "contrib"
+projects[token][version] = "1.6"
 
-projects[token_filter][version] = "1.1"
 projects[token_filter][subdir] = "contrib"
+projects[token_filter][version] = "1.1"
 
+projects[uuid][subdir] = "contrib"
 projects[uuid][download][branch] = "1.x-dev"
 projects[uuid][download][revision] = "a7bf2db"
 projects[uuid][download][type] = "git"
 projects[uuid][patch][0] = "https://www.drupal.org/files/issues/uuid_add-paragraphs-module-support-2471174.patch"
-projects[uuid][subdir] = "contrib"
 
+projects[uuid_features][subdir] = "contrib"
 projects[uuid_features][download][branch] = "1.x-dev"
 projects[uuid_features][download][revision] = "84db2dd"
 projects[uuid_features][download][type] = "git"
 projects[uuid_features][patch][0] = "https://www.drupal.org/files/issues/uuid_features-export%E2%80%93files-in%E2%80%93file-fields-with-taxonomy-terms-2454405-1.patch"
-projects[uuid_features][subdir] = "contrib"
 
-projects[variable][version] = "2.5"
 projects[variable][subdir] = "contrib"
+projects[variable][version] = "2.5"
 
+projects[views][subdir] = "contrib"
 projects[views][version] = "3.11"
 projects[views][patch][0] = "https://www.drupal.org/files/views-area-results-plural-1793500-1.patch"
 projects[views][patch][1] = "https://www.drupal.org/files/issues/views-taxonomy_multiple_term_names-1248300-46.patch"
-projects[views][subdir] = "contrib"
 
-projects[views_accordion][version] = "1.1"
 projects[views_accordion][subdir] = "contrib"
+projects[views_accordion][version] = "1.1"
 
-projects[views_bootstrap][version] = "3.1"
 projects[views_bootstrap][subdir] = "contrib"
+projects[views_bootstrap][version] = "3.1"
 
-projects[views_bulk_operations][version] = "3.2"
 projects[views_bulk_operations][subdir] = "contrib"
+projects[views_bulk_operations][version] = "3.2"
 
-projects[views_data_export][version] = "3.0-beta8"
 projects[views_data_export][subdir] = "contrib"
+projects[views_data_export][version] = "3.0-beta8"
 
-projects[views_datasource][version] = "1.0-alpha2"
 projects[views_datasource][subdir] = "contrib"
+projects[views_datasource][version] = "1.0-alpha2"
 
-projects[views_field_view][version] = "1.1"
 projects[views_field_view][subdir] = "contrib"
+projects[views_field_view][version] = "1.1"
 
-projects[webform][version] = "4.8"
 projects[webform][subdir] = "contrib"
+projects[webform][version] = "4.8"
 
-projects[webform_phone][version] = "1.21"
 projects[webform_phone][subdir] = "contrib"
+projects[webform_phone][version] = "1.21"
 
-projects[webform_uuid][version] = "1.1"
 projects[webform_uuid][subdir] = "contrib"
+projects[webform_uuid][version] = "1.1"
 
-projects[youtube][version] = "1.6"
 projects[youtube][subdir] = "contrib"
+projects[youtube][version] = "1.6"
 
 ; Libraries
 libraries[ckeditor][download][type] = "get"


### PR DESCRIPTION
flag.module was throwing various errors that would cause a WSOD. Apparently this is due to a bug in core related to cache poisoning, as well as mis-behaving contrib modules poorly integrating with Flag.

This PR just adds some patches to add some sanity checks to Flag, in the modules makefile, and re-compiles rune.make.
